### PR TITLE
Investigate homepage zoom-out display issue

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -60,7 +60,7 @@ const dtiktokConfig = {
   <meta name="description" content={description} />
   <meta name="keywords" content="DTiktok, TikTok downloader, iOS shortcut, iPhone, iPad, video download, watermark free, RHN" />
   <meta name="author" content="RHN" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3.0, minimum-scale=0.5, user-scalable=yes" />
   <!-- Favicon and App Icons -->
   <link rel="icon" type="image/x-icon" href="/favicon/favicon.ico" />
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png" />
@@ -204,6 +204,42 @@ const dtiktokConfig = {
       border-right: 2px solid #f0565f;
       min-height: 100vh;
       background: linear-gradient(135deg, #1a1a1a 0%, #202020 50%, #2a2a2a 100%);
+      /* Fix zoom-out issues */
+      position: relative;
+      overflow-x: hidden;
+      width: 100%;
+      box-sizing: border-box;
+    }
+    
+    /* Ensure all child elements respect container boundaries */
+    .main-container * {
+      box-sizing: border-box;
+    }
+    
+    /* Fix for full-width sections within constrained container */
+    .main-container .hero-section {
+      position: relative;
+      width: 100%;
+      max-width: 100%;
+      overflow: hidden;
+    }
+    
+    /* Prevent background images from breaking container */
+    .main-container .hero-section .absolute {
+      max-width: 100%;
+    }
+    
+    /* Ensure all sections respect container boundaries */
+    .main-container section {
+      width: 100%;
+      max-width: 100%;
+      box-sizing: border-box;
+    }
+    
+    /* Fix for background elements in sections */
+    .main-container section .absolute {
+      max-width: 100%;
+      box-sizing: border-box;
     }
     
     /* Gradient backgrounds - optimized to prevent layout shifts */
@@ -256,6 +292,45 @@ const dtiktokConfig = {
     /* Scroll offset for smooth navigation */
     #download, #about, #features, #why-best, #installation, #screenshots, #faq, #conclusion {
       scroll-margin-top: 100px;
+    }
+    
+    /* Additional zoom-out fixes */
+    @media (max-width: 1200px) {
+      .main-container {
+        margin: 0 auto;
+        padding: 0 10px;
+      }
+      
+      /* Ensure sections don't overflow */
+      .main-container section {
+        max-width: 100%;
+        overflow-x: hidden;
+      }
+      
+      /* Fix absolute positioned elements */
+      .main-container .absolute {
+        max-width: calc(100% - 20px);
+        left: 10px;
+        right: 10px;
+      }
+    }
+    
+    /* Prevent horizontal scrolling */
+    body {
+      overflow-x: hidden;
+    }
+    
+    /* Fix for very small zoom levels */
+    @media (max-width: 600px) {
+      .main-container {
+        border-left: 1px solid #f0565f;
+        border-right: 1px solid #f0565f;
+        padding: 0 5px;
+      }
+      
+      .hero-section {
+        padding: 0 10px;
+      }
     }
   </style>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -78,7 +78,7 @@ const faqData = [
   </script>
   
   <!-- Hero Section -->
-  <section class="relative min-h-screen flex items-center justify-center overflow-hidden">
+  <section class="hero-section relative min-h-screen flex items-center justify-center overflow-hidden">
         <!-- Background Image - Optimized for LCP with responsive loading -->
     <div class="absolute inset-0 z-0">
       <img 
@@ -88,7 +88,7 @@ const faqData = [
                 /optimized/bg/DTikTok-BG-lg.webp 1024w, 
                 /optimized/bg/DTikTok-BG-xl.webp 1440w, 
                 /optimized/bg/DTikTok-BG-2xl.webp 1920w"
-        sizes="100vw"
+        sizes="(max-width: 1200px) 100vw, 1200px"
         alt="DTikTok Background" 
         class="w-full h-full object-cover opacity-30" 
         width="1024" 
@@ -96,13 +96,13 @@ const faqData = [
         loading="eager" 
         fetchpriority="high" 
         decoding="async" 
-        style="transform: translateZ(0);"
+        style="transform: translateZ(0); max-width: 100%;"
       />
       <div class="absolute inset-0 bg-gradient-to-br from-black/70 via-black/50 to-black/70"></div>
     </div>
     
     <!-- Animated Background Elements - Deferred -->
-    <div class="absolute inset-0 z-10" style="animation-delay: 0.5s;">
+    <div class="absolute inset-0 z-10 overflow-hidden" style="animation-delay: 0.5s;">
       <div class="absolute top-20 left-20 w-32 h-32 bg-primary/20 rounded-full blur-xl animate-pulse"></div>
       <div class="absolute bottom-20 right-20 w-40 h-40 bg-secondary/20 rounded-full blur-xl animate-pulse" style="animation-delay: 1s;"></div>
       <div class="absolute top-1/2 left-1/4 w-20 h-20 bg-accent/20 rounded-full blur-xl animate-pulse" style="animation-delay: 2s;"></div>
@@ -371,7 +371,7 @@ const faqData = [
   </section>
 
   <!-- Introduction -->
-  <section class="py-20 px-6 bg-gradient-to-br from-base-100 via-base-200 to-base-100 relative overflow-hidden">
+  <section class="py-20 px-6 bg-gradient-to-br from-base-100 via-base-200 to-base-100 relative overflow-hidden max-w-full">
     <!-- Background Elements -->
     <div class="absolute inset-0 opacity-10">
       <div class="absolute top-20 left-20 w-40 h-40 bg-primary/20 rounded-full blur-3xl animate-pulse"></div>
@@ -444,7 +444,7 @@ const faqData = [
   </section>
 
   <!-- Why DTikTok is the Best -->
-  <section id="why-best" class="py-20 px-6 bg-gradient-to-br from-base-100 via-base-200 to-base-100 relative overflow-hidden">
+  <section id="why-best" class="py-20 px-6 bg-gradient-to-br from-base-100 via-base-200 to-base-100 relative overflow-hidden max-w-full">
     <!-- Background Elements -->
     <div class="absolute inset-0 opacity-20">
       <div class="absolute top-32 left-32 w-80 h-80 bg-primary/15 rounded-full blur-3xl animate-pulse"></div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,6 +30,29 @@ body {
   }
 }
 
+/* Zoom-out fixes - prevent layout breaks when zoomed out */
+@media (max-width: 1200px) {
+  /* Ensure transforms don't break container boundaries */
+  .hover\:scale-105:hover,
+  .hover\:scale-110:hover,
+  .group-hover\:scale-105,
+  .group-hover\:scale-110 {
+    transform: scale(1.02) !important;
+  }
+  
+  /* Reduce transform intensity on smaller viewports */
+  .hover\:transform:hover {
+    transform: translateY(-2px) !important;
+  }
+}
+
+/* Ultra-wide screen fixes */
+@media (min-width: 1400px) {
+  .main-container {
+    box-shadow: 0 0 50px rgba(240, 86, 95, 0.1);
+  }
+}
+
 /* Custom animations - fallback for Tailwind config */
 @keyframes fadeInUp {
   0% {


### PR DESCRIPTION
Fix zoom-out layout issues on the homepage by improving responsive containment while maintaining the 1200px max-width.

The homepage's hero section and other elements with full-width backgrounds, absolute positioning, and transform effects were breaking out of the `.main-container`'s 1200px max-width when the page was zoomed out. This PR adds specific CSS rules and adjusts the viewport meta tag to ensure all content remains properly contained and responsive across various zoom levels and screen sizes.