### PR TITLE
Fix ad container overflow

### DIFF
--- a/AD_OVERFLOW_FIXES.md
+++ b/AD_OVERFLOW_FIXES.md
@@ -1,0 +1,101 @@
+# Ad Overflow Fixes
+
+## Problem
+The ads were overflowing their designated containers, causing layout issues where ad content would extend beyond the intended ad boxes.
+
+## Root Causes Identified
+
+1. **Missing Overflow Containment**: The `.ad-container` and `.ad-content` elements didn't have `overflow: hidden` properties
+2. **No Box-sizing Control**: Ad content wasn't respecting container boundaries due to missing `box-sizing: border-box`
+3. **External Script Injection**: The external ad script from `chillimagepublisher.com` was injecting content without size constraints
+4. **Missing CSS Containment**: Modern CSS containment properties weren't being used to isolate ad content
+5. **Iframe Size Issues**: Dynamically injected iframes weren't being forced to respect container dimensions
+
+## Fixes Implemented
+
+### 1. AdBanner Component Updates (`src/components/AdBanner.astro`)
+
+**Added to `.ad-banner`:**
+- `overflow: hidden` - Prevents banner from overflowing
+- `contain: layout style` - Isolates layout calculations
+
+**Added to `.ad-container`:**
+- `overflow: hidden` - Strict container boundary enforcement
+- `box-sizing: border-box` - Ensures padding/borders are included in dimensions
+- `contain: layout style paint` - Full containment isolation
+- `position: relative` - Establishes containing block for absolute positioning
+
+**Added to `.ad-content`:**
+- `max-width: 300px` and `max-height: 250px` - Hard size limits
+- `overflow: hidden` - Prevents content overflow
+- `box-sizing: border-box` - Proper box model
+- `contain: layout style paint` - Complete containment
+- `position: relative` - Positioning context
+
+**Universal Ad Content Rules:**
+```css
+.ad-content * {
+  max-width: 100% !important;
+  max-height: 100% !important;
+  box-sizing: border-box !important;
+  overflow: hidden !important;
+}
+```
+
+**Iframe-Specific Rules:**
+```css
+.ad-content iframe {
+  width: 300px !important;
+  height: 250px !important;
+  max-width: 300px !important;
+  max-height: 250px !important;
+  border: none !important;
+  overflow: hidden !important;
+}
+```
+
+### 2. Global CSS Updates (`src/styles/global.css`)
+
+**Global Ad Containment Rules:**
+- Force all ad-related elements to respect boundaries
+- Specific targeting of ad network elements
+- Dynamic content injection protection
+- Mobile-responsive size constraints
+
+**Key Selectors:**
+- `[id^="ad-"]` - Targets elements with IDs starting with "ad-"
+- `[class*="ad-"]` - Targets elements with classes containing "ad"
+- `script[src*="chillimagepublisher.com"] + *` - Targets content injected after ad scripts
+
+## Technical Benefits
+
+1. **CSS Containment**: Using `contain: layout style paint` isolates ad rendering from the rest of the page
+2. **Overflow Control**: Multiple layers of `overflow: hidden` ensure no content escapes
+3. **Box Model Consistency**: `box-sizing: border-box` ensures predictable sizing
+4. **Responsive Design**: Mobile-specific rules maintain containment on smaller screens
+5. **Dynamic Content Protection**: Rules that catch dynamically injected content
+
+## Testing Recommendations
+
+1. **Desktop Testing**: Verify ads stay within 320px × 250px bounds
+2. **Mobile Testing**: Confirm ads respect 280px × 200px mobile constraints
+3. **Network Variations**: Test with different ad networks and content types
+4. **Dynamic Loading**: Verify containment works with lazy-loaded ads
+5. **Browser Compatibility**: Test across different browsers for CSS containment support
+
+## Fallback Considerations
+
+- CSS containment has good modern browser support
+- `overflow: hidden` provides fallback for older browsers
+- `!important` declarations ensure priority over injected styles
+- Multiple selector approaches catch various ad injection methods
+
+## Monitoring
+
+Watch for:
+- Ads still overflowing on specific devices/browsers
+- Performance impact from CSS containment
+- Ad network compatibility issues
+- Mobile viewport issues
+
+The fixes should resolve the ad overflow issues while maintaining ad functionality and performance.

--- a/src/components/AdBanner.astro
+++ b/src/components/AdBanner.astro
@@ -26,21 +26,56 @@ const adId = `ad-${Math.random().toString(36).substr(2, 9)}`;
 <style>
   .ad-banner {
     @apply w-full flex justify-center my-6;
+    /* Ensure the banner itself doesn't overflow */
+    overflow: hidden;
+    contain: layout style;
   }
   
   .ad-container {
     @apply flex flex-col items-center space-y-2 p-4 bg-gray-800/50 rounded-lg border border-gray-700;
     max-width: 320px;
+    /* Critical fixes for ad overflow */
+    overflow: hidden;
+    box-sizing: border-box;
+    contain: layout style paint;
+    position: relative;
   }
   
   .ad-label {
     @apply text-xs text-gray-400 uppercase tracking-wider font-medium;
+    /* Ensure label doesn't affect container size */
+    flex-shrink: 0;
   }
   
   .ad-content {
     @apply flex justify-center items-center;
     min-height: 250px;
     width: 300px;
+    /* Strict containment for ad content */
+    max-width: 300px;
+    max-height: 250px;
+    overflow: hidden;
+    box-sizing: border-box;
+    contain: layout style paint;
+    position: relative;
+  }
+  
+  /* Ensure any injected ad content respects container boundaries */
+  .ad-content * {
+    max-width: 100% !important;
+    max-height: 100% !important;
+    box-sizing: border-box !important;
+    overflow: hidden !important;
+  }
+  
+  /* Specific fixes for iframe ads */
+  .ad-content iframe {
+    width: 300px !important;
+    height: 250px !important;
+    max-width: 300px !important;
+    max-height: 250px !important;
+    border: none !important;
+    overflow: hidden !important;
   }
   
   /* Position-specific styles */
@@ -69,6 +104,15 @@ const adId = `ad-${Math.random().toString(36).substr(2, 9)}`;
     .ad-content {
       width: 260px;
       min-height: 200px;
+      max-width: 260px;
+      max-height: 200px;
+    }
+    
+    .ad-content iframe {
+      width: 260px !important;
+      height: 200px !important;
+      max-width: 260px !important;
+      max-height: 200px !important;
     }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -387,3 +387,48 @@ nav[aria-label="Page contents"] a {
 .progress-animation {
   animation: progress-bar 2s ease-in-out infinite;
 }
+
+/* Global ad containment fixes */
+/* Ensure all ad-related content stays within bounds */
+.ad-banner,
+.ad-container,
+.ad-content {
+  overflow: hidden !important;
+  box-sizing: border-box !important;
+}
+
+/* Force all ad scripts and iframes to respect container boundaries */
+.ad-content > *,
+.ad-content iframe,
+.ad-content div,
+.ad-content script + * {
+  max-width: 100% !important;
+  max-height: 100% !important;
+  overflow: hidden !important;
+  box-sizing: border-box !important;
+}
+
+/* Specific fixes for common ad network elements */
+[id^="ad-"],
+[class*="ad-"],
+[class*="advertisement"] {
+  overflow: hidden !important;
+  contain: layout style paint !important;
+}
+
+/* Fix for dynamically injected ad content */
+script[src*="chillimagepublisher.com"] + *,
+script[src*="invoke.js"] + * {
+  max-width: 300px !important;
+  max-height: 250px !important;
+  overflow: hidden !important;
+}
+
+/* Mobile ad containment */
+@media (max-width: 768px) {
+  script[src*="chillimagepublisher.com"] + *,
+  script[src*="invoke.js"] + * {
+    max-width: 260px !important;
+    max-height: 200px !important;
+  }
+}


### PR DESCRIPTION
Add CSS containment and overflow rules to prevent ads from overflowing their containers.

The issue stemmed from missing `overflow: hidden`, `box-sizing`, and `contain` properties in ad-related elements, compounded by external ad scripts injecting content without respecting boundaries. This PR introduces strict CSS rules in `AdBanner.astro` and `global.css` to ensure all ad content, including iframes and dynamically injected elements, stays within its defined dimensions.